### PR TITLE
Add "main" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "Provides functions for generating ordering strings",
   "type": "module",
+  "main": "src/index.js",
   "engines": {
     "node": "^14.13.1 || >=16.0.0"
   },


### PR DESCRIPTION
Was unable to import this as a module in a Jest environment without this.