### PR TITLE
docs: add link to jittered version of library

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,11 @@ const sorted = arr.toSorted((a, b) =>
 );
 ```
 
-## Other Languages
+## Other Implementations
 
-These should be byte-for-byte compatible.
+### Languages
+
+These libraries should be byte-for-byte compatible.
 
 | Language | Repo                                                  |
 | -------- | ----------------------------------------------------- |
@@ -104,3 +106,12 @@ These should be byte-for-byte compatible.
 | Python   | https://github.com/httpie/fractional-indexing-python  |
 | Kotlin   | https://github.com/darvelo/fractional-indexing-kotlin |
 | Ruby     | https://github.com/kazu-2020/fractional_indexer       |
+
+### Random Jitter
+
+To minimize the likelihood of index collisions when generating fractional indices concurrently, [random jitter](https://madebyevan.com/algos/crdt-fractional-indexing/) can be added to the generated indices. These libraries extend this package's functionality with random jitter.
+
+| Language   | Repo                                                         |
+| ---------- | ------------------------------------------------------------ |
+| TypeScript | https://github.com/nathanhleung/jittered-fractional-indexing |
+

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ These libraries should be byte-for-byte compatible.
 
 ### Random Jitter
 
-To minimize the likelihood of index collisions when generating fractional indices concurrently, [random jitter](https://madebyevan.com/algos/crdt-fractional-indexing/) can be added to the generated indices. These libraries extend this package's functionality with random jitter.
+To minimize the likelihood of index collisions when generating fractional indexes concurrently, [random jitter](https://madebyevan.com/algos/crdt-fractional-indexing/) can be added to the generated indices. These libraries extend this package's functionality with random jitter.
 
 | Language   | Repo                                                         |
 | ---------- | ------------------------------------------------------------ |


### PR DESCRIPTION
I needed a jittered version of the library for collaborative realtime editing (as proposed in @evanw's [follow-up](https://madebyevan.com/algos/crdt-fractional-indexing/) to the OG [Realtime Editing of Ordered Sequences](https://www.figma.com/blog/realtime-editing-of-ordered-sequences/)) — but saw that the existing jittered alternative may not respect all invariants (https://github.com/tldraw/tldraw/issues/5864) so wrote a thin wrapper over this library which implements jittering: https://github.com/nathanhleung/jittered-fractional-indexing

From the README:

> This package uses [rocicorp/fractional-indexing](https://github.com/rocicorp/fractional-indexing) under the hood, and generates jitter by binary splitting the key range until the desired number of bits of entropy is reached. For instance, if one bit of jitter is desired:
> 
> 1. First, we generate an initial index, `midpoint`, between the specified lower bound `a` and upper bound `b` using the original, unjittered `fractional-indexing` package.
> 1. Then, with 50% probability each, we either generate a key between the original lower bound `a` and the `midpoint`, or a key between the `midpoint` and the original upper bound `b`.
> 1. At this point, we have one bit of randomness, so we return this key.
> 1. For more jitter, the process is repeated with the newly-generated key as the new lower or upper bound, with 50% probability each.

Figured it might be helpful to have this in the README alongside the other language implementations in case other people also need a jittered implementation, so wanted to propose this change (but understandable if you'd consider this out of scope for this package). Let me know what you think.