### PR TITLE
feat: add intDigits parameter to customize integer-part head alphabet

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,10 @@
 export const BASE_62_DIGITS =
   "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
+// When `intDigits` is not supplied, the integer-part head alphabet defaults to
+// A-Z (negative lengths) followed by a-z (positive lengths) -- i.e. the
+// equivalent of "ABC...XYZ" + "abc...xyz".
+
 // `a` may be empty string, `b` is null or non-empty string.
 // `a < b` lexicographically if `b` is non-null.
 // no trailing zeros allowed.
@@ -60,37 +64,53 @@ function midpoint(a, b, digits) {
 
 /**
  * @param {string} int
+ * @param {string | undefined} intDigits
  * @return {void}
  */
 
-function validateInteger(int) {
-  if (int.length !== getIntegerLength(int[0])) {
+function validateInteger(int, intDigits) {
+  if (int.length !== getIntegerLength(int[0], intDigits)) {
     throw new Error("invalid integer part of order key: " + int);
   }
 }
 
 /**
  * @param {string} head
+ * @param {string | undefined} intDigits
  * @return {number}
  */
-
-function getIntegerLength(head) {
-  if (head >= "a" && head <= "z") {
-    return head.charCodeAt(0) - "a".charCodeAt(0) + 2;
-  } else if (head >= "A" && head <= "Z") {
-    return "Z".charCodeAt(0) - head.charCodeAt(0) + 2;
+function getIntegerLength(head, intDigits) {
+  if (intDigits === undefined) {
+    const c = head.charCodeAt(0);
+    if (c >= 97 && c <= 122) { // 'a' - 'z'
+      return c - 97 + 2; // 'a'
+    }
+    if (c >= 65 && c <= 90) { // 'A' - 'Z'
+      return 90 - c + 2; // 'Z'
+    }
   } else {
-    throw new Error("invalid order key head: " + head);
+    // intDigits is a single lexicographically ordered (ascending) alphabet: the
+    // first half are the negative-length heads and the second half the
+    // positive-length heads, mirroring the default A-Z/a-z scheme. The outermost
+    // characters mark the longest integer parts, and the two heads straddling
+    // the midpoint mark the shortest (length 2).
+    const i = intDigits.indexOf(head);
+    if (i !== -1) {
+      const half = intDigits.length / 2;
+      return i < half ? half - i + 1 : i - half + 2;
+    }
   }
+  throw new Error("invalid order key head: " + head);
 }
 
 /**
  * @param {string} key
+ * @param {string | undefined} intDigits
  * @return {string}
  */
 
-function getIntegerPart(key) {
-  const integerPartLength = getIntegerLength(key[0]);
+function getIntegerPart(key, intDigits) {
+  const integerPartLength = getIntegerLength(key[0], intDigits);
   if (integerPartLength > key.length) {
     throw new Error("invalid order key: " + key);
   }
@@ -100,17 +120,18 @@ function getIntegerPart(key) {
 /**
  * @param {string} key
  * @param {string} digits
+ * @param {string | undefined} intDigits
  * @return {void}
  */
 
-function validateOrderKey(key, digits) {
-  if (isSmallestInteger(key, digits)) {
+function validateOrderKey(key, digits, intDigits) {
+  if (isSmallestInteger(key, digits, intDigits)) {
     throw new Error("invalid order key: " + key);
   }
   // getIntegerPart will throw if the first character is bad,
   // or the key is too short.  we'd call it to check these things
   // even if we didn't need the result
-  const i = getIntegerPart(key);
+  const i = getIntegerPart(key, intDigits);
   const f = key.slice(i.length);
   if (f.slice(-1) === digits[0]) {
     throw new Error("invalid order key: " + key);
@@ -121,10 +142,11 @@ function validateOrderKey(key, digits) {
 /**
  * @param {string} x
  * @param {string} digits
+ * @param {string | undefined} intDigits
  * @return {string | null}
  */
-function incrementInteger(x, digits) {
-  validateInteger(x);
+function incrementInteger(x, digits, intDigits) {
+  validateInteger(x, intDigits);
   const [head, ...digs] = x.split("");
   let carry = true;
   for (let i = digs.length - 1; carry && i >= 0; i--) {
@@ -137,16 +159,35 @@ function incrementInteger(x, digits) {
     }
   }
   if (carry) {
-    if (head === "Z") {
-      return "a" + digits[0];
+    if (intDigits === undefined) {
+      // fast path for the default A-Z/a-z markers.
+      if (head === "Z") {
+        return "a" + digits[0];
+      }
+      if (head === "z") {
+        return null;
+      }
+      const h = String.fromCharCode(head.charCodeAt(0) + 1);
+      if (h > "a") {
+        digs.push(digits[0]);
+      } else {
+        digs.pop();
+      }
+      return h + digs.join("");
     }
-    if (head === "z") {
+    const headIndex = intDigits.indexOf(head);
+    if (headIndex === intDigits.length - 1) {
+      // already the largest integer
       return null;
     }
-    const h = String.fromCharCode(head.charCodeAt(0) + 1);
-    if (h > "a") {
+    const h = intDigits[headIndex + 1];
+    // the head moves one step toward the largest digit; grow or shrink the digit
+    // run to match the new head's integer length.
+    const lengthDelta =
+      getIntegerLength(h, intDigits) - getIntegerLength(head, intDigits);
+    if (lengthDelta > 0) {
       digs.push(digits[0]);
-    } else {
+    } else if (lengthDelta < 0) {
       digs.pop();
     }
     return h + digs.join("");
@@ -159,11 +200,12 @@ function incrementInteger(x, digits) {
 /**
  * @param {string} x
  * @param {string} digits
+ * @param {string | undefined} intDigits
  * @return {string | null}
  */
 
-function decrementInteger(x, digits) {
-  validateInteger(x);
+function decrementInteger(x, digits, intDigits) {
+  validateInteger(x, intDigits);
   const [head, ...digs] = x.split("");
   let borrow = true;
   for (let i = digs.length - 1; borrow && i >= 0; i--) {
@@ -176,16 +218,35 @@ function decrementInteger(x, digits) {
     }
   }
   if (borrow) {
-    if (head === "a") {
-      return "Z" + digits.slice(-1);
+    if (intDigits === undefined) {
+      // fast path for the default A-Z/a-z markers.
+      if (head === "a") {
+        return "Z" + digits.slice(-1);
+      }
+      if (head === "A") {
+        return null;
+      }
+      const h = String.fromCharCode(head.charCodeAt(0) - 1);
+      if (h < "Z") {
+        digs.push(digits.slice(-1));
+      } else {
+        digs.pop();
+      }
+      return h + digs.join("");
     }
-    if (head === "A") {
+    const headIndex = intDigits.indexOf(head);
+    if (headIndex === 0) {
+      // already the smallest integer
       return null;
     }
-    const h = String.fromCharCode(head.charCodeAt(0) - 1);
-    if (h < "Z") {
+    const h = intDigits[headIndex - 1];
+    // the head moves one step toward the smallest digit; grow or shrink the
+    // digit run to match the new head's integer length.
+    const lengthDelta =
+      getIntegerLength(h, intDigits) - getIntegerLength(head, intDigits);
+    if (lengthDelta > 0) {
       digs.push(digits.slice(-1));
-    } else {
+    } else if (lengthDelta < 0) {
       digs.pop();
     }
     return h + digs.join("");
@@ -195,21 +256,28 @@ function decrementInteger(x, digits) {
 }
 
 /**
- * @type {Record<string, string>}
+ * @type {Map<string, string>}
  */
-const repeatedKeysCache = Object.create(null);
+const repeatedKeysCache = new Map();
 
 /**
  * @param {string} key
  * @param {string} digits
+ * @param {string | undefined} intDigits
  */
-function isSmallestInteger(key, digits) {
+function isSmallestInteger(key, digits, intDigits) {
+  // The smallest integer is the most-negative head (the first character of
+  // intDigits, marking the longest integer part) followed by all-zero digits.
   // Use a cache to avoid constructing the same long string over and over which
   // causes unnecessary GC pressure.
-  let cached = repeatedKeysCache[digits[0]];
+  const cacheKey = (intDigits === undefined ? "" : intDigits) + " " + digits[0];
+  let cached = repeatedKeysCache.get(cacheKey);
   if (!cached) {
-    cached = "A" + digits[0].repeat(26);
-    repeatedKeysCache[digits[0]] = cached;
+    cached =
+      intDigits === undefined
+        ? "A" + digits[0].repeat(26)
+        : intDigits[0] + digits[0].repeat(intDigits.length / 2);
+    repeatedKeysCache.set(cacheKey, cached);
   }
   return key === cached;
 }
@@ -227,24 +295,47 @@ function isSmallestInteger(key, digits) {
  * unsorted alphabet produces keys that do not sort correctly.
  *
  * Note that `digits` only defines the *digit values* of a key. The integer
- * part of every key also begins with a length/magnitude marker drawn from a
- * fixed Latin alphabet (a-z for positive lengths, A-Z for negative), regardless
- * of `digits`. So e.g. base-10 keys look like "a0", "b00" or "Z9" -- the
- * leading letter is part of the key format, not a digit. This marker only ever
- * occupies the first position and is only compared against other markers, which
- * is why alphabets that omit a-z/A-Z still sort correctly.
+ * part of every key also begins with a length/magnitude marker drawn from the
+ * `intDigits` alphabet (A-Z for negative lengths, a-z for positive by default),
+ * regardless of `digits`. So e.g. base-10 keys look like "a0", "b00" or "Z9" --
+ * the leading character is a head marker, not a fractional digit. This marker
+ * only ever occupies the first position and is only compared against other
+ * markers, which is why `digits` and `intDigits` may overlap (or be identical)
+ * and keys still sort correctly.
+ *
+ * `intDigits` overrides that marker alphabet. It is a single alphabet in
+ * ascending (lexicographical) character order, with even length: its first half
+ * are the negative-length heads and its second half the positive-length heads.
+ * The outermost characters mark the longest integer parts and the two characters
+ * straddling the midpoint mark the shortest (length 2). The integer part may
+ * grow until it reaches the outermost heads, so a shorter alphabet limits how
+ * large/small a key's integer part can become. Defaults to the equivalent of
+ * "ABC...XYZ" + "abc...xyz".
+ *
+ * @example
+ * // intDigits may reuse the digit alphabet itself. Here both are base-10, so
+ * // keys contain no letters: the first half (0-4) are negative heads, the
+ * // second half (5-9) positive heads, and 4/5 mark the shortest (length-2)
+ * // integer parts.
+ * generateKeyBetween(null, null, "0123456789", "0123456789"); // => "50"
  *
  * @param {string | null | undefined} a
  * @param {string | null | undefined} b
  * @param {string=} digits
+ * @param {string=} intDigits
  * @return {string}
  */
-export function generateKeyBetween(a, b, digits = BASE_62_DIGITS) {
+export function generateKeyBetween(
+  a,
+  b,
+  digits = BASE_62_DIGITS,
+  intDigits = undefined
+) {
   if (a != null) {
-    validateOrderKey(a, digits);
+    validateOrderKey(a, digits, intDigits);
   }
   if (b != null) {
-    validateOrderKey(b, digits);
+    validateOrderKey(b, digits, intDigits);
   }
   if (a != null && b != null) {
     // swap if out of order, so that a < b.  this is just a convenience for
@@ -258,18 +349,22 @@ export function generateKeyBetween(a, b, digits = BASE_62_DIGITS) {
 
   if (a == null) {
     if (b == null) {
-      return "a" + digits[0];
+      // the shortest positive head: "a" by default, else the first character of
+      // the second half of intDigits.
+      const head =
+        intDigits === undefined ? "a" : intDigits[intDigits.length / 2];
+      return head + digits[0];
     }
 
-    const ib = getIntegerPart(b);
+    const ib = getIntegerPart(b, intDigits);
     const fb = b.slice(ib.length);
-    if (isSmallestInteger(ib, digits)) {
+    if (isSmallestInteger(ib, digits, intDigits)) {
       return ib + midpoint("", fb, digits);
     }
     if (ib < b) {
       return ib;
     }
-    const res = decrementInteger(ib, digits);
+    const res = decrementInteger(ib, digits, intDigits);
     if (res == null) {
       throw new Error("cannot decrement any more");
     }
@@ -277,20 +372,20 @@ export function generateKeyBetween(a, b, digits = BASE_62_DIGITS) {
   }
 
   if (b == null) {
-    const ia = getIntegerPart(a);
+    const ia = getIntegerPart(a, intDigits);
     const fa = a.slice(ia.length);
-    const i = incrementInteger(ia, digits);
+    const i = incrementInteger(ia, digits, intDigits);
     return i == null ? ia + midpoint(fa, null, digits) : i;
   }
 
-  const ia = getIntegerPart(a);
+  const ia = getIntegerPart(a, intDigits);
   const fa = a.slice(ia.length);
-  const ib = getIntegerPart(b);
+  const ib = getIntegerPart(b, intDigits);
   const fb = b.slice(ib.length);
   if (ia === ib) {
     return ia + midpoint(fa, fb, digits);
   }
-  const i = incrementInteger(ia, digits);
+  const i = incrementInteger(ia, digits, intDigits);
   if (i == null) {
     throw new Error("cannot increment any more");
   }
@@ -312,39 +407,46 @@ export function generateKeyBetween(a, b, digits = BASE_62_DIGITS) {
  * @param {string | null | undefined} b
  * @param {number} n
  * @param {string} digits
+ * @param {string | undefined} intDigits
  * @return {string[]}
  */
-export function generateNKeysBetween(a, b, n, digits = BASE_62_DIGITS) {
+export function generateNKeysBetween(
+  a,
+  b,
+  n,
+  digits = BASE_62_DIGITS,
+  intDigits = undefined
+) {
   if (n === 0) {
     return [];
   }
   if (n === 1) {
-    return [generateKeyBetween(a, b, digits)];
+    return [generateKeyBetween(a, b, digits, intDigits)];
   }
   if (b == null) {
-    let c = generateKeyBetween(a, b, digits);
+    let c = generateKeyBetween(a, b, digits, intDigits);
     const result = [c];
     for (let i = 0; i < n - 1; i++) {
-      c = generateKeyBetween(c, b, digits);
+      c = generateKeyBetween(c, b, digits, intDigits);
       result.push(c);
     }
     return result;
   }
   if (a == null) {
-    let c = generateKeyBetween(a, b, digits);
+    let c = generateKeyBetween(a, b, digits, intDigits);
     const result = [c];
     for (let i = 0; i < n - 1; i++) {
-      c = generateKeyBetween(a, c, digits);
+      c = generateKeyBetween(a, c, digits, intDigits);
       result.push(c);
     }
     result.reverse();
     return result;
   }
   const mid = Math.floor(n / 2);
-  const c = generateKeyBetween(a, b, digits);
+  const c = generateKeyBetween(a, b, digits, intDigits);
   return [
-    ...generateNKeysBetween(a, c, mid, digits),
+    ...generateNKeysBetween(a, c, mid, digits, intDigits),
     c,
-    ...generateNKeysBetween(c, b, n - mid - 1, digits),
+    ...generateNKeysBetween(c, b, n - mid - 1, digits, intDigits),
   ];
 }

--- a/src/index.js
+++ b/src/index.js
@@ -82,10 +82,12 @@ function validateInteger(int, intDigits) {
 function getIntegerLength(head, intDigits) {
   if (intDigits === undefined) {
     const c = head.charCodeAt(0);
-    if (c >= 97 && c <= 122) { // 'a' - 'z'
+    if (c >= 97 && c <= 122) {
+      // 'a' - 'z'
       return c - 97 + 2; // 'a'
     }
-    if (c >= 65 && c <= 90) { // 'A' - 'Z'
+    if (c >= 65 && c <= 90) {
+      // 'A' - 'Z'
       return 90 - c + 2; // 'Z'
     }
   } else {
@@ -256,28 +258,36 @@ function decrementInteger(x, digits, intDigits) {
 }
 
 /**
- * @type {Map<string, string>}
+ * Two-level cache keyed by (intDigits, first digit char code). Nesting the maps
+ * lets us look up with the raw `intDigits` string and a primitive char code,
+ * avoiding the per-call allocation of a combined string key.
+ * @type {Map<string, Map<number, string>>}
  */
 const repeatedKeysCache = new Map();
 
 /**
  * @param {string} key
  * @param {string} digits
- * @param {string | undefined} intDigits
+ * @param {string=} intDigits Special case undefined as "" to get a Map of string.
  */
-function isSmallestInteger(key, digits, intDigits) {
+function isSmallestInteger(key, digits, intDigits = "") {
   // The smallest integer is the most-negative head (the first character of
   // intDigits, marking the longest integer part) followed by all-zero digits.
   // Use a cache to avoid constructing the same long string over and over which
   // causes unnecessary GC pressure.
-  const cacheKey = JSON.stringify([intDigits, digits[0]]);
-  let cached = repeatedKeysCache.get(cacheKey);
-  if (!cached) {
+  let byDigit = repeatedKeysCache.get(intDigits);
+  if (byDigit === undefined) {
+    byDigit = new Map();
+    repeatedKeysCache.set(intDigits, byDigit);
+  }
+  const zeroCode = digits.charCodeAt(0);
+  let cached = byDigit.get(zeroCode);
+  if (cached === undefined) {
     cached =
-      intDigits === undefined
+      intDigits === ""
         ? "A" + digits[0].repeat(26)
         : intDigits[0] + digits[0].repeat(intDigits.length / 2);
-    repeatedKeysCache.set(cacheKey, cached);
+    byDigit.set(zeroCode, cached);
   }
   return key === cached;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -283,6 +283,81 @@ function isSmallestInteger(key, digits, intDigits) {
 }
 
 /**
+ * Returns true if every character of `s` has a strictly greater character code
+ * than the one before it (ascending order, which also rules out duplicates).
+ * @param {string} s
+ * @return {boolean}
+ */
+function isStrictlyAscending(s) {
+  for (let i = 1; i < s.length; i++) {
+    if (s.charCodeAt(i - 1) >= s.charCodeAt(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Alphabets that have already passed `validateDigits`. Validation is pure and
+ * its result never changes, so we cache the alphabet to skip re-scanning it on
+ * every call. Kept separate from `validatedIntDigits` because the two have
+ * different rules (an odd-length string is a valid `digits` but not `intDigits`).
+ * @type {Set<string>}
+ */
+const validatedDigits = new Set();
+
+/**
+ * Validates a fractional-digit alphabet: at least two characters, in strictly
+ * ascending character-code order.
+ * @param {string} digits
+ * @return {void}
+ */
+function validateDigits(digits) {
+  if (validatedDigits.has(digits)) {
+    return;
+  }
+  if (digits.length < 2 || !isStrictlyAscending(digits)) {
+    throw new Error(
+      "digits must be at least 2 characters in strictly ascending character " +
+        "code order: " +
+        digits
+    );
+  }
+  validatedDigits.add(digits);
+}
+
+/**
+ * Alphabets that have already passed `validateIntDigits`.
+ * @type {Set<string>}
+ */
+const validatedIntDigits = new Set();
+
+/**
+ * Validates a head-marker alphabet: an even number of at least two characters
+ * (its two halves are the negative- and positive-length heads), in strictly
+ * ascending character-code order.
+ * @param {string} intDigits
+ * @return {void}
+ */
+function validateIntDigits(intDigits) {
+  if (validatedIntDigits.has(intDigits)) {
+    return;
+  }
+  if (
+    intDigits.length < 2 ||
+    intDigits.length % 2 !== 0 ||
+    !isStrictlyAscending(intDigits)
+  ) {
+    throw new Error(
+      "intDigits must be an even number of at least 2 characters in strictly " +
+        "ascending character code order: " +
+        intDigits
+    );
+  }
+  validatedIntDigits.add(intDigits);
+}
+
+/**
  * Generates an order key that sorts between `a` and `b`.
  *
  * `a` is the lower bound: an order key, or null for the start.
@@ -331,6 +406,10 @@ export function generateKeyBetween(
   digits = BASE_62_DIGITS,
   intDigits = undefined
 ) {
+  validateDigits(digits);
+  if (intDigits !== undefined) {
+    validateIntDigits(intDigits);
+  }
   if (a != null) {
     validateOrderKey(a, digits, intDigits);
   }
@@ -417,6 +496,10 @@ export function generateNKeysBetween(
   digits = BASE_62_DIGITS,
   intDigits = undefined
 ) {
+  validateDigits(digits);
+  if (intDigits !== undefined) {
+    validateIntDigits(intDigits);
+  }
   if (n === 0) {
     return [];
   }

--- a/src/index.js
+++ b/src/index.js
@@ -270,7 +270,7 @@ function isSmallestInteger(key, digits, intDigits) {
   // intDigits, marking the longest integer part) followed by all-zero digits.
   // Use a cache to avoid constructing the same long string over and over which
   // causes unnecessary GC pressure.
-  const cacheKey = (intDigits === undefined ? "" : intDigits) + " " + digits[0];
+  const cacheKey = JSON.stringify([intDigits, digits[0]]);
   let cached = repeatedKeysCache.get(cacheKey);
   if (!cached) {
     cached =

--- a/src/test.js
+++ b/src/test.js
@@ -268,6 +268,62 @@ testIntDigits("0123456789", "0123456789", "59", null, "600");
 testIntDigits("0123456789", "0123456789", null, "50", "49");
 testIntDigits("0123456789", "0123456789", "56", "57", "565");
 
+// `digits` and `intDigits` are validated once at the start of the public API.
+// `digits` must be at least two characters in strictly ascending character-code
+// order (which also rules out duplicates).
+testIntDigits(
+  "0213456789",
+  "ABab",
+  null,
+  null,
+  "digits must be at least 2 characters in strictly ascending character code order: 0213456789"
+);
+testIntDigits(
+  "0",
+  "ABab",
+  null,
+  null,
+  "digits must be at least 2 characters in strictly ascending character code order: 0"
+);
+testIntDigits(
+  "0012",
+  "ABab",
+  null,
+  null,
+  "digits must be at least 2 characters in strictly ascending character code order: 0012"
+);
+// `intDigits` must additionally be of even length (its two halves are the
+// negative- and positive-length heads).
+testIntDigits(
+  "0123456789",
+  "abc",
+  null,
+  null,
+  "intDigits must be an even number of at least 2 characters in strictly ascending character code order: abc"
+);
+testIntDigits(
+  "0123456789",
+  "ba",
+  null,
+  null,
+  "intDigits must be an even number of at least 2 characters in strictly ascending character code order: ba"
+);
+testIntDigits(
+  "0123456789",
+  "",
+  null,
+  null,
+  "intDigits must be an even number of at least 2 characters in strictly ascending character code order: "
+);
+// Validation also guards the generateNKeysBetween entry point.
+testNDigits(
+  "0",
+  null,
+  null,
+  5,
+  "digits must be at least 2 characters in strictly ascending character code order: 0"
+);
+
 testOrdering("01");
 testOrdering("0123456789");
 testOrdering("ΑΒΓΔΕΖΗΘ");

--- a/src/test.js
+++ b/src/test.js
@@ -1,6 +1,25 @@
 import { generateKeyBetween, generateNKeysBetween } from "./index.js";
 
 /**
+ * @param {string} digits
+ * @param {string} intDigits
+ * @param {string | null} a
+ * @param {string | null} b
+ * @param {string} exp
+ */
+function testIntDigits(digits, intDigits, a, b, exp) {
+  /** @type {string} */
+  let act;
+  try {
+    act = generateKeyBetween(a, b, digits, intDigits);
+  } catch (exp) {
+    act = exp.message;
+  }
+
+  console.assert(exp == act, `${exp} == ${act}`);
+}
+
+/**
  * @param {string | null} a
  * @param {string | null} b
  * @param {string} exp
@@ -164,8 +183,9 @@ testNDigits(" !#$%", "a ", "a!", 1, "a $");
 // ascending alphabet.  Insert at random positions and verify ordering holds.
 /**
  * @param {string} digits
+ * @param {string} [intDigits]
  */
-function testOrdering(digits) {
+function testOrdering(digits, intDigits) {
   let seed = 1;
   const rnd = () =>
     (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
@@ -175,22 +195,83 @@ function testOrdering(digits) {
     const pos = Math.floor(rnd() * (list.length + 1));
     const a = pos > 0 ? list[pos - 1] : null;
     const b = pos < list.length ? list[pos] : null;
-    const k = generateKeyBetween(a, b, digits);
+    const k = generateKeyBetween(a, b, digits, intDigits);
     console.assert(
       (a === null || a < k) && (b === null || k < b),
-      `out of range for ${JSON.stringify(digits)}: ${a} < ${k} < ${b}`
+      `out of range for ${JSON.stringify(digits)}/${JSON.stringify(
+        intDigits
+      )}: ${a} < ${k} < ${b}`
     );
     list.splice(pos, 0, k);
   }
   const sorted = [...list].sort();
   console.assert(
     sorted.every((v, i) => v === list[i]),
-    `not stably sorted for ${JSON.stringify(digits)}`
+    `not stably sorted for ${JSON.stringify(digits)}/${JSON.stringify(
+      intDigits
+    )}`
   );
 }
+
+// `intDigits` overrides the integer-part head alphabet (which defaults to the
+// hardcoded a-z/A-Z markers).  It is a single ascending (lexicographically
+// ordered) alphabet: the first half are the negative-length heads and the second
+// half the positive-length heads.  The outermost characters mark the longest
+// integer parts and the two heads straddling the midpoint mark the shortest
+// (length 2).  Restricting it to a shorter alphabet limits how long the integer
+// part may grow, and any head outside `intDigits` is invalid.
+
+// Limit negative heads to "A","B" and positive heads to "a","b"; the inner pair
+// (B, a) mark length 2 and the outer pair (A, b) mark length 3.
+testIntDigits("0123456789", "ABab", "a0", "a1", "a05");
+testIntDigits("0123456789", "ABab", "a9", null, "b00");
+testIntDigits("0123456789", "ABab", "b00", null, "b01");
+testIntDigits("0123456789", "ABab", "a0", null, "a1");
+testIntDigits("0123456789", "ABab", null, "B9", "B8");
+// A head outside the limited alphabet is rejected.
+testIntDigits("0123456789", "ABab", "c00", null, "invalid order key head: c");
+testIntDigits("0123456789", "ABab", "00", "01", "invalid order key head: 0");
+
+// An undefined `intDigits` must behave identically to passing the explicit
+// default head alphabet in ascending order: the negative heads A-Z followed by
+// the positive heads a-z (so Z and a, straddling the midpoint, both mark
+// length 2, mirroring the default Z->2 and a->2).
+const DEFAULT_INT_DIGITS =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "abcdefghijklmnopqrstuvwxyz";
+{
+  let seed = 1;
+  const rnd = () =>
+    (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+  const digits = "0123456789";
+  /** @type {string[]} */
+  const list = [];
+  for (let i = 0; i < 2000; i++) {
+    const pos = Math.floor(rnd() * (list.length + 1));
+    const a = pos > 0 ? list[pos - 1] : null;
+    const b = pos < list.length ? list[pos] : null;
+    const def = generateKeyBetween(a, b, digits);
+    const cust = generateKeyBetween(a, b, digits, DEFAULT_INT_DIGITS);
+    console.assert(
+      def === cust,
+      `undefined intDigits should match default alphabet: ${a},${b} => ${def} !== ${cust}`
+    );
+    list.splice(pos, 0, def);
+  }
+}
+
+// `intDigits` may be identical to `digits`, producing keys with no letters at
+// all: the first half (0-4) are negative heads and the second half (5-9)
+// positive heads, so 4 and 5 mark the shortest (length-2) integer parts.
+testIntDigits("0123456789", "0123456789", null, null, "50");
+testIntDigits("0123456789", "0123456789", "50", null, "51");
+testIntDigits("0123456789", "0123456789", "59", null, "600");
+testIntDigits("0123456789", "0123456789", null, "50", "49");
+testIntDigits("0123456789", "0123456789", "56", "57", "565");
 
 testOrdering("01");
 testOrdering("0123456789");
 testOrdering("ΑΒΓΔΕΖΗΘ");
 testOrdering(" !#$%");
 testOrdering("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+// digits and intDigits identical (base-10 keys with no letters).
+testOrdering("0123456789", "0123456789");


### PR DESCRIPTION
Adds an optional `intDigits` parameter to `generateKeyBetween` that overrides the fixed A-Z/a-z length markers, enabling fully custom (e.g. all-digit) key alphabets. When omitted, behavior is unchanged.

Fixes #22