### PR TITLE
feat!: Default the head digits to the digits

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Generate a single key in between two points.
 generateKeyBetween(
   a: string | null | undefined, // start
   b: string | null | undefined, // end
-  digits?: string | undefined = BASE_62_DIGITS, // optional character encoding
+  digits?: string, // digit alphabet, defaults to BASE_62_DIGITS (0-9A-Za-z)
+  intDigits?: string, // integer-head alphabet, defaults to `digits`
 ): string;
 ```
 
@@ -48,8 +49,9 @@ Use this when generating multiple keys at some known position, as it spaces out 
 generateNKeysBetween(
   a: string | null | undefined, // start
   b: string | null | undefined, // end
-  n: number // number of keys to generate evenly between start and end
-  digits?: string | undefined = BASE_62_DIGITS, // optional character encoding
+  n: number, // number of keys to generate evenly between start and end
+  digits?: string, // digit alphabet, defaults to BASE_62_DIGITS (0-9A-Za-z)
+  intDigits?: string, // integer-head alphabet, defaults to `digits`
 ): string[];
 ```
 
@@ -78,10 +80,10 @@ base&nbsp;10:
 ```js
 import { generateNKeysBetween } from "fractional-indexing";
 
-generateNKeysBetween(null, null, 4, "0123456789"); // ["a0", "a1", "a2", "a3"]
+generateNKeysBetween(null, null, 4, "0123456789"); // ["50", "51", "52", "53"]
 ```
 
-There are two important rules and one thing that surprises people:
+`digits` must obey two rules:
 
 1. **`digits` must be single-byte and sorted in ascending character-code
    order**, with no duplicates. Every character must have a char code in the
@@ -94,16 +96,39 @@ There are two important rules and one thing that surprises people:
    (symbols, Latin-1, etc.) work fine as long as they are sorted by character
    code. Multi-byte alphabets (e.g. Greek) are rejected.
 
-3. **Generated keys always contain Latin head characters (`a`-`z` and `A`-`Z`)
-   regardless of `digits`.** The integer part of every key begins with a
-   magnitude/length marker drawn from a fixed Latin alphabet (`a`-`z` for
-   positive lengths, `A`-`Z` for negative), independent of `digits`. So a base-10
-   key looks like `"a0"`, `"b00"`, or `"Z9"` — the leading letter is _not_ one of
-   your digits. This is part of the order-key format (matching the reference
-   implementation) and is required for keys to sort correctly; it is not a digit
-   value. The marker only ever occupies the first position and is only compared
-   against other markers, which is why custom alphabets that don't contain these
-   letters still sort correctly.
+### Integer heads and `intDigits`
+
+The integer part of every key begins with a magnitude/length marker — a
+**head** — drawn from the `intDigits` alphabet. `intDigits` is split in half:
+the first half are the negative-length heads and the second half the
+positive-length heads, so it must have an **even length**. The head only ever
+occupies the first position and is only compared against other heads, which is
+why `digits` and `intDigits` may overlap (or be identical) and keys still sort
+correctly.
+
+`intDigits` **defaults to `digits`**, so a custom alphabet is _self-headed_: a
+base-10 key looks like `"50"`, `"600"`, or `"49"`, with no Latin letters.
+
+When you omit `digits` entirely, `intDigits` falls back to `BASE_52_DIGITS`
+(`A-Z` for negative lengths, `a-z` for positive), so the default keys look like
+`"a0"`, `"b00"`, or `"Z9"` — the classic format, byte-compatible with the other
+implementations listed below. Note that passing `digits` _explicitly_ (even
+`BASE_62_DIGITS`) makes the keys self-headed; only omitting `digits` yields the
+`A-Z`/`a-z` heads.
+
+To use a custom `digits` but keep the classic Latin heads — or to use an
+**odd-length** `digits`, which can't supply its own even head alphabet — pass
+`intDigits` explicitly:
+
+```js
+import { generateNKeysBetween, BASE_52_DIGITS } from "fractional-indexing";
+
+// self-headed (intDigits defaults to digits):
+generateNKeysBetween(null, null, 4, "0123456789"); // ["50", "51", "52", "53"]
+
+// Latin heads (intDigits set explicitly):
+generateNKeysBetween(null, null, 4, "0123456789", BASE_52_DIGITS); // ["a0", "a1", "a2", "a3"]
+```
 
 ## Sorting
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,14 @@
 // This is based on https://observablehq.com/@dgreensp/implementing-fractional-indexing
 
 export const BASE_62_DIGITS =
-  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"; // 0-9 + A-Z + a-z
 
-// When `intDigits` is not supplied, the integer-part head alphabet defaults to
-// A-Z (negative lengths) followed by a-z (positive lengths) -- i.e. the
-// equivalent of "ABC...XYZ" + "abc...xyz".
+export const BASE_52_DIGITS = BASE_62_DIGITS.slice(10); // A-Z + a-z
+
+// `intDigits` (the integer-part head alphabet) defaults to `digits`. When
+// `digits` is also omitted it falls back to BASE_52_DIGITS -- A-Z (negative
+// lengths) followed by a-z (positive lengths) -- so the default keys keep the
+// classic "a0", "Zz", ... form.
 
 /**
  * Per-alphabet cache mapping each digit's char code to its index, so digit->value
@@ -91,55 +94,48 @@ function midpoint(a, b, digits, lookup) {
 
 /**
  * @param {string} int
- * @param {string | undefined} intDigits
+ * @param {string} intDigits
+ * @param {Uint8Array} intLookup
  * @return {void}
  */
 
-function validateInteger(int, intDigits) {
-  if (int.length !== getIntegerLength(int[0], intDigits)) {
+function validateInteger(int, intDigits, intLookup) {
+  if (int.length !== getIntegerLength(int[0], intDigits, intLookup)) {
     throw new Error("invalid integer part of order key: " + int);
   }
 }
 
 /**
  * @param {string} head
- * @param {string | undefined} intDigits
+ * @param {string} intDigits
+ * @param {Uint8Array} intLookup
  * @return {number}
  */
-function getIntegerLength(head, intDigits) {
-  if (intDigits === undefined) {
-    const c = head.charCodeAt(0);
-    if (c >= 97 && c <= 122) {
-      // 'a' - 'z'
-      return c - 97 + 2; // 'a'
-    }
-    if (c >= 65 && c <= 90) {
-      // 'A' - 'Z'
-      return 90 - c + 2; // 'Z'
-    }
-  } else {
-    // intDigits is a single lexicographically ordered (ascending) alphabet: the
-    // first half are the negative-length heads and the second half the
-    // positive-length heads, mirroring the default A-Z/a-z scheme. The outermost
-    // characters mark the longest integer parts, and the two heads straddling
-    // the midpoint mark the shortest (length 2).
-    const i = intDigits.indexOf(head);
-    if (i !== -1) {
-      const half = intDigits.length / 2;
-      return i < half ? half - i + 1 : i - half + 2;
-    }
+function getIntegerLength(head, intDigits, intLookup) {
+  // intDigits is a single lexicographically ordered (ascending) alphabet: the
+  // first half are the negative-length heads and the second half the
+  // positive-length heads (the default A-Z/a-z markers are just one such
+  // alphabet). The outermost characters mark the longest integer parts, and the
+  // two heads straddling the midpoint mark the shortest (length 2).
+  const i = intLookup[head.charCodeAt(0)];
+  // `intLookup` returns 0 for any char code not in the alphabet, so confirm the
+  // char really is at index `i` before trusting it as a head.
+  if (intDigits[i] === head) {
+    const half = intDigits.length / 2;
+    return i < half ? half - i + 1 : i - half + 2;
   }
   throw new Error("invalid order key head: " + head);
 }
 
 /**
  * @param {string} key
- * @param {string | undefined} intDigits
+ * @param {string} intDigits
+ * @param {Uint8Array} intLookup
  * @return {string}
  */
 
-function getIntegerPart(key, intDigits) {
-  const integerPartLength = getIntegerLength(key[0], intDigits);
+function getIntegerPart(key, intDigits, intLookup) {
+  const integerPartLength = getIntegerLength(key[0], intDigits, intLookup);
   if (integerPartLength > key.length) {
     throw new Error("invalid order key: " + key);
   }
@@ -149,18 +145,18 @@ function getIntegerPart(key, intDigits) {
 /**
  * @param {string} key
  * @param {string} digits
- * @param {string | undefined} intDigits
+ * @param {string} intDigits
+ * @param {Uint8Array} intLookup
  * @return {void}
  */
-
-function validateOrderKey(key, digits, intDigits) {
+function validateOrderKey(key, digits, intDigits, intLookup) {
   if (isSmallestInteger(key, digits, intDigits)) {
     throw new Error("invalid order key: " + key);
   }
   // getIntegerPart will throw if the first character is bad,
   // or the key is too short.  we'd call it to check these things
   // even if we didn't need the result
-  const i = getIntegerPart(key, intDigits);
+  const i = getIntegerPart(key, intDigits, intLookup);
   const f = key.slice(i.length);
   if (f.slice(-1) === digits[0]) {
     throw new Error("invalid order key: " + key);
@@ -172,11 +168,12 @@ function validateOrderKey(key, digits, intDigits) {
  * @param {string} x
  * @param {string} digits
  * @param {Uint8Array} lookup
- * @param {string | undefined} intDigits
+ * @param {string} intDigits
+ * @param {Uint8Array} intLookup
  * @return {string | null}
  */
-function incrementInteger(x, digits, lookup, intDigits) {
-  validateInteger(x, intDigits);
+function incrementInteger(x, digits, lookup, intDigits, intLookup) {
+  validateInteger(x, intDigits, intLookup);
   const head = x[0];
   const zero = digits[0];
   // Walk the digit run right-to-left, turning maxed-out digits into zeros
@@ -191,18 +188,7 @@ function incrementInteger(x, digits, lookup, intDigits) {
     }
   }
   // carry out of the whole digit run; `trailing` is now all zeros.
-  if (intDigits === undefined) {
-    // fast path for the default A-Z/a-z markers.
-    if (head === "Z") {
-      return "a" + zero;
-    }
-    if (head === "z") {
-      return null;
-    }
-    const h = String.fromCharCode(head.charCodeAt(0) + 1);
-    return h + (h > "a" ? trailing + zero : trailing.slice(1));
-  }
-  const headIndex = intDigits.indexOf(head);
+  const headIndex = intLookup[head.charCodeAt(0)];
   if (headIndex === intDigits.length - 1) {
     // already the largest integer
     return null;
@@ -211,7 +197,8 @@ function incrementInteger(x, digits, lookup, intDigits) {
   // the head moves one step toward the largest digit; grow or shrink the digit
   // run to match the new head's integer length.
   const lengthDelta =
-    getIntegerLength(h, intDigits) - getIntegerLength(head, intDigits);
+    getIntegerLength(h, intDigits, intLookup) -
+    getIntegerLength(head, intDigits, intLookup);
   return (
     h +
     (lengthDelta > 0
@@ -227,12 +214,13 @@ function incrementInteger(x, digits, lookup, intDigits) {
  * @param {string} x
  * @param {string} digits
  * @param {Uint8Array} lookup
- * @param {string | undefined} intDigits
+ * @param {string} intDigits
+ * @param {Uint8Array} intLookup
  * @return {string | null}
  */
 
-function decrementInteger(x, digits, lookup, intDigits) {
-  validateInteger(x, intDigits);
+function decrementInteger(x, digits, lookup, intDigits, intLookup) {
+  validateInteger(x, intDigits, intLookup);
   const head = x[0];
   const last = digits[digits.length - 1];
   // Walk the digit run right-to-left, turning underflowed digits into the
@@ -247,18 +235,7 @@ function decrementInteger(x, digits, lookup, intDigits) {
     }
   }
   // borrow out of the whole digit run; `trailing` is now all max digits.
-  if (intDigits === undefined) {
-    // fast path for the default A-Z/a-z markers.
-    if (head === "a") {
-      return "Z" + last;
-    }
-    if (head === "A") {
-      return null;
-    }
-    const h = String.fromCharCode(head.charCodeAt(0) - 1);
-    return h + (h < "Z" ? trailing + last : trailing.slice(1));
-  }
-  const headIndex = intDigits.indexOf(head);
+  const headIndex = intLookup[head.charCodeAt(0)];
   if (headIndex === 0) {
     // already the smallest integer
     return null;
@@ -267,7 +244,8 @@ function decrementInteger(x, digits, lookup, intDigits) {
   // the head moves one step toward the smallest digit; grow or shrink the
   // digit run to match the new head's integer length.
   const lengthDelta =
-    getIntegerLength(h, intDigits) - getIntegerLength(head, intDigits);
+    getIntegerLength(h, intDigits, intLookup) -
+    getIntegerLength(head, intDigits, intLookup);
   return (
     h +
     (lengthDelta > 0
@@ -289,9 +267,9 @@ const repeatedKeysCache = new Map();
 /**
  * @param {string} key
  * @param {string} digits
- * @param {string=} intDigits Special case undefined as "" to get a Map of string.
+ * @param {string} intDigits
  */
-function isSmallestInteger(key, digits, intDigits = "") {
+function isSmallestInteger(key, digits, intDigits) {
   // The smallest integer is the most-negative head (the first character of
   // intDigits, marking the longest integer part) followed by all-zero digits.
   // Use a cache to avoid constructing the same long string over and over which
@@ -304,10 +282,7 @@ function isSmallestInteger(key, digits, intDigits = "") {
   const zeroCode = digits.charCodeAt(0);
   let cached = byDigit.get(zeroCode);
   if (cached === undefined) {
-    cached =
-      intDigits === ""
-        ? "A" + digits[0].repeat(26)
-        : intDigits[0] + digits[0].repeat(intDigits.length / 2);
+    cached = intDigits[0] + digits[0].repeat(intDigits.length / 2);
     byDigit.set(zeroCode, cached);
   }
   return key === cached;
@@ -422,32 +397,34 @@ function validateIntDigits(intDigits) {
  * `digits` is the alphabet, e.g. '0123456789' for base 10. Its characters
  * must be single-byte (char code 0-255) and in ascending character code order;
  * both are validated. It may otherwise be any alphabet (it does not need to
- * contain 0-9, A-Z or a-z).
+ * contain 0-9, A-Z or a-z). Because `intDigits` defaults to `digits`, an
+ * odd-length `digits` must be paired with an explicit even-length `intDigits`.
  *
  * Note that `digits` only defines the *digit values* of a key. The integer
- * part of every key also begins with a length/magnitude marker drawn from the
- * `intDigits` alphabet (A-Z for negative lengths, a-z for positive by default),
- * regardless of `digits`. So e.g. base-10 keys look like "a0", "b00" or "Z9" --
- * the leading character is a head marker, not a fractional digit. This marker
- * only ever occupies the first position and is only compared against other
- * markers, which is why `digits` and `intDigits` may overlap (or be identical)
- * and keys still sort correctly.
+ * part of every key also begins with a length/magnitude marker (a "head") drawn
+ * from the `intDigits` alphabet. The head only ever occupies the first position
+ * and is only compared against other heads, which is why `digits` and
+ * `intDigits` may overlap (or be identical) and keys still sort correctly.
  *
- * `intDigits` overrides that marker alphabet. It is a single alphabet in
- * ascending (lexicographical) character order, with even length: its first half
- * are the negative-length heads and its second half the positive-length heads.
- * The outermost characters mark the longest integer parts and the two characters
+ * `intDigits` is the head alphabet: a single alphabet in ascending
+ * (lexicographical) character order, with even length. Its first half are the
+ * negative-length heads and its second half the positive-length heads. The
+ * outermost characters mark the longest integer parts and the two characters
  * straddling the midpoint mark the shortest (length 2). The integer part may
  * grow until it reaches the outermost heads, so a shorter alphabet limits how
- * large/small a key's integer part can become. Defaults to the equivalent of
- * "ABC...XYZ" + "abc...xyz".
+ * large/small a key's integer part can become.
+ *
+ * `intDigits` defaults to `digits`, so a base-10 alphabet produces self-headed
+ * keys like "50", "600" or "49". When `digits` is also omitted it falls back to
+ * BASE_52_DIGITS (A-Z/a-z), giving the classic "a0", "b00", "Z9" form. Note that
+ * passing `digits` explicitly (even BASE_62_DIGITS) makes the keys self-headed;
+ * only omitting `digits` entirely yields the A-Z/a-z heads.
  *
  * @example
- * // intDigits may reuse the digit alphabet itself. Here both are base-10, so
- * // keys contain no letters: the first half (0-4) are negative heads, the
- * // second half (5-9) positive heads, and 4/5 mark the shortest (length-2)
- * // integer parts.
- * generateKeyBetween(null, null, "0123456789", "0123456789"); // => "50"
+ * // base 10: heads come from `digits` itself. The first half (0-4) are negative
+ * // heads, the second half (5-9) positive heads, and 4/5 mark the shortest
+ * // (length-2) integer parts.
+ * generateKeyBetween(null, null, "0123456789"); // => "50"
  *
  * @param {string | null | undefined} a
  * @param {string | null | undefined} b
@@ -458,19 +435,27 @@ function validateIntDigits(intDigits) {
 export function generateKeyBetween(
   a,
   b,
-  digits = BASE_62_DIGITS,
+  digits = undefined,
   intDigits = undefined
 ) {
-  validateDigits(digits);
   if (intDigits !== undefined) {
     validateIntDigits(intDigits);
+  } else {
+    intDigits = digits ?? BASE_52_DIGITS;
   }
+  if (digits !== undefined) {
+    validateDigits(digits);
+  } else {
+    digits = BASE_62_DIGITS;
+  }
+
   const lookup = getDigitIndex(digits);
+  const intLookup = getDigitIndex(intDigits);
   if (a != null) {
-    validateOrderKey(a, digits, intDigits);
+    validateOrderKey(a, digits, intDigits, intLookup);
   }
   if (b != null) {
-    validateOrderKey(b, digits, intDigits);
+    validateOrderKey(b, digits, intDigits, intLookup);
   }
   if (a != null && b != null) {
     // swap if out of order, so that a < b.  this is just a convenience for
@@ -484,14 +469,13 @@ export function generateKeyBetween(
 
   if (a == null) {
     if (b == null) {
-      // the shortest positive head: "a" by default, else the first character of
-      // the second half of intDigits.
-      const head =
-        intDigits === undefined ? "a" : intDigits[intDigits.length / 2];
+      // the shortest positive head: the first character of the second half of
+      // intDigits ("a" for the default A-Z/a-z markers).
+      const head = intDigits[intDigits.length / 2];
       return head + digits[0];
     }
 
-    const ib = getIntegerPart(b, intDigits);
+    const ib = getIntegerPart(b, intDigits, intLookup);
     const fb = b.slice(ib.length);
     if (isSmallestInteger(ib, digits, intDigits)) {
       return ib + midpoint("", fb, digits, lookup);
@@ -499,7 +483,7 @@ export function generateKeyBetween(
     if (ib < b) {
       return ib;
     }
-    const res = decrementInteger(ib, digits, lookup, intDigits);
+    const res = decrementInteger(ib, digits, lookup, intDigits, intLookup);
     if (res == null) {
       throw new Error("cannot decrement any more");
     }
@@ -507,20 +491,20 @@ export function generateKeyBetween(
   }
 
   if (b == null) {
-    const ia = getIntegerPart(a, intDigits);
+    const ia = getIntegerPart(a, intDigits, intLookup);
     const fa = a.slice(ia.length);
-    const i = incrementInteger(ia, digits, lookup, intDigits);
+    const i = incrementInteger(ia, digits, lookup, intDigits, intLookup);
     return i == null ? ia + midpoint(fa, null, digits, lookup) : i;
   }
 
-  const ia = getIntegerPart(a, intDigits);
+  const ia = getIntegerPart(a, intDigits, intLookup);
   const fa = a.slice(ia.length);
-  const ib = getIntegerPart(b, intDigits);
+  const ib = getIntegerPart(b, intDigits, intLookup);
   const fb = b.slice(ib.length);
   if (ia === ib) {
     return ia + midpoint(fa, fb, digits, lookup);
   }
-  const i = incrementInteger(ia, digits, lookup, intDigits);
+  const i = incrementInteger(ia, digits, lookup, intDigits, intLookup);
   if (i == null) {
     throw new Error("cannot increment any more");
   }
@@ -541,21 +525,28 @@ export function generateKeyBetween(
  * @param {string | null | undefined} a
  * @param {string | null | undefined} b
  * @param {number} n
- * @param {string} digits
- * @param {string | undefined} intDigits
+ * @param {string=} digits
+ * @param {string=} intDigits
  * @return {string[]}
  */
 export function generateNKeysBetween(
   a,
   b,
   n,
-  digits = BASE_62_DIGITS,
+  digits = undefined,
   intDigits = undefined
 ) {
-  validateDigits(digits);
   if (intDigits !== undefined) {
     validateIntDigits(intDigits);
+  } else {
+    intDigits = digits ?? BASE_52_DIGITS;
   }
+  if (digits !== undefined) {
+    validateDigits(digits);
+  } else {
+    digits = BASE_62_DIGITS;
+  }
+
   if (n === 0) {
     return [];
   }

--- a/src/test.js
+++ b/src/test.js
@@ -1,4 +1,8 @@
-import { generateKeyBetween, generateNKeysBetween } from "./index.js";
+import {
+  generateKeyBetween,
+  generateNKeysBetween,
+  BASE_52_DIGITS,
+} from "./index.js";
 
 /**
  * @param {string} digits
@@ -12,8 +16,8 @@ function testIntDigits(digits, intDigits, a, b, exp) {
   let act;
   try {
     act = generateKeyBetween(a, b, digits, intDigits);
-  } catch (exp) {
-    act = exp.message;
+  } catch (e) {
+    act = e.message;
   }
 
   console.assert(exp == act, `${exp} == ${act}`);
@@ -29,13 +33,15 @@ function test(a, b, exp) {
   let act;
   try {
     act = generateKeyBetween(a, b);
-  } catch (exp) {
-    act = exp.message;
+  } catch (e) {
+    act = e.message;
   }
 
   console.assert(exp == act, `${exp} == ${act}`);
 }
 
+// With no `digits` and no `intDigits` the default is unchanged: BASE_62 digits
+// with the A-Z/a-z head markers, so keys still look like "a0", "Zz", ...
 test(null, null, "a0");
 test(null, "a0", "Zz");
 test(null, "Zz", "Zy");
@@ -81,21 +87,24 @@ function testN(a, b, n, exp) {
   let act;
   try {
     act = generateNKeysBetween(a, b, n, BASE_10_DIGITS).join(" ");
-  } catch (exp) {
-    act = exp.message;
+  } catch (e) {
+    act = e.message;
   }
 
   console.assert(exp == act, `${exp} == ${act}`);
 }
 
-testN(null, null, 5, "a0 a1 a2 a3 a4");
-testN("a4", null, 10, "a5 a6 a7 a8 a9 b00 b01 b02 b03 b04");
-testN(null, "a0", 5, "Z5 Z6 Z7 Z8 Z9");
+// A custom `digits` with no `intDigits` now uses `digits` itself as the head
+// alphabet, so base-10 keys contain no letters: heads 0-4 are negative lengths,
+// 5-9 positive, and 4/5 mark the shortest (length-2) integer parts.
+testN(null, null, 5, "50 51 52 53 54");
+testN("54", null, 10, "55 56 57 58 59 600 601 602 603 604");
+testN(null, "50", 5, "45 46 47 48 49");
 testN(
-  "a0",
-  "a2",
+  "50",
+  "52",
   20,
-  "a01 a02 a03 a035 a04 a05 a06 a07 a08 a09 a1 a11 a12 a13 a14 a15 a16 a17 a18 a19"
+  "501 502 503 5035 504 505 506 507 508 509 51 511 512 513 514 515 516 517 518 519"
 );
 
 /**
@@ -110,9 +119,11 @@ function testBase95(a, b, exp) {
   /** @type {string} */
   let act;
   try {
-    act = generateKeyBetween(a, b, BASE_95_DIGITS);
-  } catch (exp) {
-    act = exp.message;
+    // base-95 is odd-length, so it can't supply its own (even) head alphabet;
+    // pass the default A-Z/a-z markers explicitly to keep Latin heads.
+    act = generateKeyBetween(a, b, BASE_95_DIGITS, BASE_52_DIGITS);
+  } catch (e) {
+    act = e.message;
   }
 
   console.assert(exp == act, `${exp} == ${act}`);
@@ -141,11 +152,10 @@ testBase95(
 );
 
 // Custom alphabets that do not contain the Latin head characters a-z/A-Z work
-// fine, as long as the digits are single-byte (char code 0-255) and sorted in
-// ascending character-code order. Note that the generated keys still contain
-// Latin head characters (the leading "a", "b", "Z", ... below), because those
-// are the integer-part magnitude markers and are not part of the `digits`
-// alphabet.
+// fine, as long as the digits are even-length, single-byte (char code 0-255),
+// and sorted in ascending character-code order. With no `intDigits` the digit
+// alphabet itself supplies the integer heads, so the generated keys are
+// self-headed (no Latin letters).
 
 /**
  * @param {string} digits
@@ -159,17 +169,23 @@ function testNDigits(digits, a, b, n, exp) {
   let act;
   try {
     act = generateNKeysBetween(a, b, n, digits).join(" ");
-  } catch (exp) {
-    act = exp.message;
+  } catch (e) {
+    act = e.message;
   }
 
   console.assert(exp == act, `${exp} == ${act}`);
 }
 
-// Base 2.
-testNDigits("01", null, null, 8, "a0 a1 b00 b01 b10 b11 c000 c001");
-testNDigits("01", "a1", null, 1, "b00");
-testNDigits("01", "a0", "a1", 1, "a01");
+// Base 2: the integer range is tiny (only heads "0" and "1").
+testNDigits(
+  "01",
+  null,
+  null,
+  8,
+  "10 11 111 1111 11111 111111 1111111 11111111"
+);
+testNDigits("01", "10", null, 1, "11");
+testNDigits("01", "10", "11", 1, "101");
 
 // Keys must be single-byte: a multi-byte alphabet (e.g. Greek, U+0391..) is
 // rejected, but Latin-1 characters (char code 128-255) are allowed.
@@ -180,12 +196,11 @@ testNDigits(
   10,
   "digits must be single-byte (char code 0-255): ΑΒΓΔΕΖΗΘ"
 );
-// Latin-1 alphabet (¡=161 .. ¥=165), all within the single-byte range.
-testNDigits("¡¢£¤¥", null, null, 6, "a¡ a¢ a£ a¤ a¥ b¡¡");
+// A Latin-1 alphabet (¡=161 .. ¦=166), all within the single-byte range.
+testNDigits("¡¢£¤¥¦", null, null, 6, "¤¡ ¤¢ ¤£ ¤¤ ¤¥ ¤¦");
 
 // An alphabet of symbols whose character codes are all below "A".
-testNDigits(" !#$%", null, null, 6, "a  a! a# a$ a% b  ");
-testNDigits(" !#$%", "a ", "a!", 1, "a $");
+testNDigits(" !#$%&", null, null, 6, "$  $! $# $$ $% $&");
 
 // Generated keys must sort with ordinary lexicographic comparison for any
 // ascending alphabet.  Insert at random positions and verify ordering holds.
@@ -222,12 +237,13 @@ function testOrdering(digits, intDigits) {
 }
 
 // `intDigits` overrides the integer-part head alphabet (which defaults to the
-// hardcoded a-z/A-Z markers).  It is a single ascending (lexicographically
-// ordered) alphabet: the first half are the negative-length heads and the second
-// half the positive-length heads.  The outermost characters mark the longest
-// integer parts and the two heads straddling the midpoint mark the shortest
-// (length 2).  Restricting it to a shorter alphabet limits how long the integer
-// part may grow, and any head outside `intDigits` is invalid.
+// digit alphabet, or to the A-Z/a-z markers when no `digits` is given).  It is a
+// single ascending (lexicographically ordered) alphabet: the first half are the
+// negative-length heads and the second half the positive-length heads.  The
+// outermost characters mark the longest integer parts and the two heads
+// straddling the midpoint mark the shortest (length 2).  Restricting it to a
+// shorter alphabet limits how long the integer part may grow, and any head
+// outside `intDigits` is invalid.
 
 // Limit negative heads to "A","B" and positive heads to "a","b"; the inner pair
 // (B, a) mark length 2 and the outer pair (A, b) mark length 3.
@@ -240,12 +256,8 @@ testIntDigits("0123456789", "ABab", null, "B9", "B8");
 testIntDigits("0123456789", "ABab", "c00", null, "invalid order key head: c");
 testIntDigits("0123456789", "ABab", "00", "01", "invalid order key head: 0");
 
-// An undefined `intDigits` must behave identically to passing the explicit
-// default head alphabet in ascending order: the negative heads A-Z followed by
-// the positive heads a-z (so Z and a, straddling the midpoint, both mark
-// length 2, mirroring the default Z->2 and a->2).
-const DEFAULT_INT_DIGITS =
-  "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "abcdefghijklmnopqrstuvwxyz";
+// An omitted `intDigits` defaults to `digits`, so it must behave identically to
+// passing `digits` as the head alphabet.
 {
   let seed = 1;
   const rnd = () =>
@@ -258,18 +270,19 @@ const DEFAULT_INT_DIGITS =
     const a = pos > 0 ? list[pos - 1] : null;
     const b = pos < list.length ? list[pos] : null;
     const def = generateKeyBetween(a, b, digits);
-    const cust = generateKeyBetween(a, b, digits, DEFAULT_INT_DIGITS);
+    const cust = generateKeyBetween(a, b, digits, digits);
     console.assert(
       def === cust,
-      `undefined intDigits should match default alphabet: ${a},${b} => ${def} !== ${cust}`
+      `omitted intDigits should match digits: ${a},${b} => ${def} !== ${cust}`
     );
     list.splice(pos, 0, def);
   }
 }
 
-// `intDigits` may be identical to `digits`, producing keys with no letters at
-// all: the first half (0-4) are negative heads and the second half (5-9)
-// positive heads, so 4 and 5 mark the shortest (length-2) integer parts.
+// `intDigits` may be identical to `digits` (which is now also the default),
+// producing keys with no letters at all: the first half (0-4) are negative heads
+// and the second half (5-9) positive heads, so 4 and 5 mark the shortest
+// (length-2) integer parts.
 testIntDigits("0123456789", "0123456789", null, null, "50");
 testIntDigits("0123456789", "0123456789", "50", null, "51");
 testIntDigits("0123456789", "0123456789", "59", null, "600");
@@ -340,9 +353,12 @@ testNDigits(
   "digits must be at least 2 characters in strictly ascending character code order: 0"
 );
 
-testOrdering("01");
 testOrdering("0123456789");
-testOrdering(" !#$%");
+testOrdering(" !#$%&");
+testOrdering("¡¢£¤¥¦");
 testOrdering("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+// base 2 self-heading has too small an integer range to sustain 1000 inserts,
+// so give it the wider A-Z/a-z head alphabet.
+testOrdering("01", BASE_52_DIGITS);
 // digits and intDigits identical (base-10 keys with no letters).
 testOrdering("0123456789", "0123456789");


### PR DESCRIPTION
`intDigits` now defaults to `digits` rather than the fixed A-Z/a-z head alphabet, so a custom `digits` is self-headed by default: base-10 keys become "50", "600", "49" instead of "a0", "b00", "Z9". When `digits` is also omitted, `intDigits` falls back to the new exported BASE_52_DIGITS (A-Z/a-z), so the no-argument default is unchanged and stays byte-compatible with the other implementations.

- Add and export BASE_52_DIGITS; BASE_62_DIGITS is now "0-9" + BASE_52.
- Replace intDigits.indexOf(head) with a cached Uint8Array lookup table threaded through the head-index helpers; getIntegerLength confirms membership via intDigits[i] === head (lookup returns 0 for absent chars).
- Drop now-dead intDigits === undefined / "" branches.
- Update tests for self-headed custom alphabets; pass intDigits explicitly where Latin heads are still wanted (base-95, base-2 ordering).
- Refresh comments and README: document intDigits, the even-length head requirement, the odd-length-digits caveat, and the explicit-digits self-heading quirk.

Note: odd-length `digits` must be paired with an explicit even-length `intDigits`. Run `npm run build` to regenerate src/index.d.ts.